### PR TITLE
updates scale so resulting image is 1:1

### DIFF
--- a/lib/headless/headless.go
+++ b/lib/headless/headless.go
@@ -51,7 +51,7 @@ func (c *Chrome) NewImage(ctx context.Context, addr string, x, y, width, height 
 		Y:      y,
 		Width:  width,
 		Height: height,
-		Scale:  1.0,
+		Scale:  0.5,
 	}).Do(ctx, currentTarget)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When `Scale:  1.0` the resulting image size is 2x.

I'd expect setting window=400x300 returns a cropped 400x300 image. 

<img width="326" alt="screen shot 2018-11-08 at 9 10 21 pm" src="https://user-images.githubusercontent.com/6278244/48239089-925ffb80-e39b-11e8-83f6-2a8e45b011cf.png">